### PR TITLE
Item repository iteration 0

### DIFF
--- a/data/items_short.csv
+++ b/data/items_short.csv
@@ -1,0 +1,4 @@
+id,name,description,unit_price,merchant_id,created_at,updated_at
+263399953,Moyenne toile,Acrylique sur toile et collage.,3000,12334395,2016-01-11 11:46:06 UTC,1980-11-23 09:11:30 UTC
+263400305,Magnifique toile Street Art/Modern Art - Nike Air Max,"Magnifique toile Street Art 50x100cm réalisée avec peinture acrylique, peinture 3D, collage mosaïque, feutre Posca.",40000,12334401,2016-01-11 11:44:13 UTC,1990-10-06 04:14:15 UTC
+263404585,Thukdokhin wax cord,"width 2.5 cm, change size by slide , weight 23 g",72000,12334371,2016-01-11 13:32:00 UTC,2011-01-21 23:59:14 UTC

--- a/lib/findable.rb
+++ b/lib/findable.rb
@@ -1,0 +1,11 @@
+module Findable
+
+  def find_by_id (id_num)
+    index = @all.rindex{|object| object.id == id_num}
+    return @all[index]
+  end
+
+  def find_by_name (name)
+    @all.find{|object| object.name.downcase == name.downcase}
+  end
+end

--- a/lib/item.rb
+++ b/lib/item.rb
@@ -20,4 +20,11 @@ class Item
   def unit_price_to_dollars
     unit_price.to_f.round(2)
   end
+
+  def update (updated_info_hash)
+    @name = updated_info_hash[:name] if updated_info_hash[:name]
+    @description = updated_info_hash[:description] if updated_info_hash[:description]
+    @unit_price = updated_info_hash[:unit_price] if updated_info_hash[:unit_price]
+    @updated_at = Time.now.getutc
+  end 
 end

--- a/lib/item.rb
+++ b/lib/item.rb
@@ -24,7 +24,7 @@ class Item
   def update (updated_info_hash)
     @name = updated_info_hash[:name] if updated_info_hash[:name]
     @description = updated_info_hash[:description] if updated_info_hash[:description]
-    @unit_price = updated_info_hash[:unit_price] if updated_info_hash[:unit_price]
+    @unit_price = BigDecimal.new((updated_info_hash[:unit_price].to_f / 100).round(2), 4) if updated_info_hash[:unit_price]
     @updated_at = Time.now.getutc
-  end 
+  end
 end

--- a/lib/item_repository.rb
+++ b/lib/item_repository.rb
@@ -3,7 +3,9 @@ require 'pry'
 require_relative './sales_engine.rb'
 require_relative './findable.rb'
 require_relative './item.rb'
+require 'BigDecimal'
 
+#This class takes one argument at initialization, an array of all Item instances. It is intended that the SalesEngine instance will take care of creating this array from its given CSV directory, and pass that array to this instance of ItemRepository at time of creation (when SalesEngine#items(item_object_array) is called)
 class ItemRepository < SalesEngine
   include Findable
   attr_reader :all
@@ -12,15 +14,17 @@ class ItemRepository < SalesEngine
     @all = array
   end
 
-  def self.from_csv (path_string)
-    csv_source = CSV.read(path_string, headers: true, header_converters: :symbol)
-    item_object_array = []
-    csv_source.each do |line|
-      item = Item.new({ id: line[:id], name: line[:name], description: line[:description], merchant_id: line[:merchant_id], unit_price: line[:unit_price], created_at: line[:created_at], updated_at: line[:updated_at] })
-      item_object_array << item
-    end
-    self.new(item_object_array)
-  end
+  # vvv LET'S MOVE THIS LOGIC TO THE SALES ENGINE CLASS! vvv (with some modification)
+  # def self.from_csv (path_string)
+  #   csv_source = CSV.read(path_string, headers: true, header_converters: :symbol)
+  #   item_object_array = []
+  #   csv_source.each do |line|
+  #     item = Item.new({ id: line[:id].to_i, name: line[:name], description: line[:description], merchant_id: line[:merchant_id].to_i, unit_price: BigDecimal.new((line[:unit_price].to_f / 100).round(2), line[:unit_price].digits.count), created_at: line[:created_at], updated_at: line[:updated_at] })
+  #     item_object_array << item
+  #   end
+  #   self.new(item_object_array)
+  # end
+  # ^^^ LET'S MOVE THIS LOGIC TO THE SALES ENGINE CLASS! ^^^
 
   def find_all_with_description (descriptive_string)
     @all.find_all {|item| item.description.downcase.include?(descriptive_string.downcase)}

--- a/lib/item_repository.rb
+++ b/lib/item_repository.rb
@@ -35,6 +35,18 @@ class ItemRepository < SalesEngine
 
   def find_all_by_merchant_id(merchant_id)
     @all.find_all {|item| item.merchant_id == merchant_id}
-  end 
+  end
 
+  def create(info_hash)
+    current_largest_item_id = (@all.max {|current, subsequent| current.id <=> subsequent.id}).id #@all.max returns an Item instance, on which we can call id
+    info_hash[:id] = current_largest_item_id + 1
+    info_hash[:created_at] = Time.now.getutc if !(info_hash[:created_at])
+    info_hash[:updated_at] = Time.now.getutc
+    new_item = Item.new(info_hash)
+    @all << new_item
+  end
+
+  def update(id, info_hash)
+    find_by_id(id).update(info_hash)
+  end
 end

--- a/lib/item_repository.rb
+++ b/lib/item_repository.rb
@@ -1,0 +1,22 @@
+require 'CSV'
+require 'pry'
+require_relative '../lib/sales_engine.rb'
+
+class ItemRepository < SalesEngine
+  attr_reader :all
+
+  def initialize array
+    @all = array
+  end
+
+  def self.from_csv (path_string)
+    csv_array = CSV.read(path_string, headers: true, header_converters: :symbol)
+    item_object_array = []
+    csv_array.each do |line|
+      item = Item.new({ id: line[:id], name: line[:name], description: line[:description], merchant_id: line[:merchant_id], created_at: line[:created_at], updated_at: line[:updated_at] })
+      item_object_array << item
+    end
+    self.new(item_object_array)
+  end
+
+end

--- a/lib/item_repository.rb
+++ b/lib/item_repository.rb
@@ -29,7 +29,7 @@ class ItemRepository < SalesEngine
     @all.find_all {|item| item.unit_price == desired_price}
   end
 
-  def find_all_by_price_in_rance(price_range_object)
+  def find_all_by_price_in_range(price_range_object)
     @all.find_all {|item| price_range_object.member?(item.unit_price)}
 
   end

--- a/lib/item_repository.rb
+++ b/lib/item_repository.rb
@@ -1,7 +1,8 @@
 require 'CSV'
 require 'pry'
-require_relative '../lib/sales_engine.rb'
-require_relative '../lib/findable.rb'
+require_relative './sales_engine.rb'
+require_relative './findable.rb'
+require_relative './item.rb'
 
 class ItemRepository < SalesEngine
   include Findable
@@ -12,10 +13,10 @@ class ItemRepository < SalesEngine
   end
 
   def self.from_csv (path_string)
-    csv_array = CSV.read(path_string, headers: true, header_converters: :symbol)
+    csv_source = CSV.read(path_string, headers: true, header_converters: :symbol)
     item_object_array = []
-    csv_array.each do |line|
-      item = Item.new({ id: line[:id], name: line[:name], description: line[:description], merchant_id: line[:merchant_id], created_at: line[:created_at], updated_at: line[:updated_at] })
+    csv_source.each do |line|
+      item = Item.new({ id: line[:id], name: line[:name], description: line[:description], merchant_id: line[:merchant_id], unit_price: line[:unit_price], created_at: line[:created_at], updated_at: line[:updated_at] })
       item_object_array << item
     end
     self.new(item_object_array)
@@ -25,15 +26,16 @@ class ItemRepository < SalesEngine
     @all.find_all {|item| item.description.downcase.include?(descriptive_string.downcase)}
   end
 
+  #note- price in this hash is stored in cents, not dollars!
   def find_all_by_price (desired_price)
-    @all.find_all {|item| item.unit_price == desired_price}
+    @all.find_all {|item| item.unit_price.to_i == desired_price}
   end
 
   def find_all_by_price_in_range(price_range_object)
-    @all.find_all {|item| price_range_object.member?(item.unit_price)}
+    @all.find_all {|item| price_range_object.member?(item.unit_price.to_i)}
   end
 
-  def find_all_by_merchant_id(merchant_id)
+  def find_all_by_merchant_id(merchant_id_string)
     @all.find_all {|item| item.merchant_id == merchant_id}
   end
 

--- a/lib/item_repository.rb
+++ b/lib/item_repository.rb
@@ -1,8 +1,10 @@
 require 'CSV'
 require 'pry'
 require_relative '../lib/sales_engine.rb'
+require_relative '../lib/findable.rb'
 
 class ItemRepository < SalesEngine
+  include Findable
   attr_reader :all
 
   def initialize array
@@ -17,6 +19,14 @@ class ItemRepository < SalesEngine
       item_object_array << item
     end
     self.new(item_object_array)
+  end
+
+  def find_all_with_description (descriptive_string)
+    @all.find_all {|item| item.description.downcase.include?(descriptive_string.downcase)}
+  end
+
+  def find_all_by_price (desired_price)
+    @all.find_all {|item| item.unit_price == desired_price}
   end
 
 end

--- a/lib/item_repository.rb
+++ b/lib/item_repository.rb
@@ -29,4 +29,9 @@ class ItemRepository < SalesEngine
     @all.find_all {|item| item.unit_price == desired_price}
   end
 
+  def find_all_by_price_in_rance(price_range_object)
+    @all.find_all {|item| price_range_object.member?(item.unit_price)}
+
+  end
+
 end

--- a/lib/item_repository.rb
+++ b/lib/item_repository.rb
@@ -31,7 +31,10 @@ class ItemRepository < SalesEngine
 
   def find_all_by_price_in_range(price_range_object)
     @all.find_all {|item| price_range_object.member?(item.unit_price)}
-
   end
+
+  def find_all_by_merchant_id(merchant_id)
+    @all.find_all {|item| item.merchant_id == merchant_id}
+  end 
 
 end

--- a/lib/item_repository.rb
+++ b/lib/item_repository.rb
@@ -49,4 +49,9 @@ class ItemRepository < SalesEngine
   def update(id, info_hash)
     find_by_id(id).update(info_hash)
   end
+
+  def delete (id)
+    index = @all.find_index(find_by_id(id))
+    @all.delete_at(index)
+  end
 end

--- a/lib/sales_engine.rb
+++ b/lib/sales_engine.rb
@@ -1,0 +1,13 @@
+class SalesEngine
+
+  def self.from_csv (path_string)
+    csv_array = CSV.read(path_string, headers: true, header_converters: :symbol)
+    item_object_array = []
+    csv_array.each do |line|
+      item = Item.new({ id: line[:id], name: line[:name], description: line[:description], merchant_id: line[:merchant_id], created_at: line[:created_at], updated_at: line[:updated_at] })
+      item_object_array << item
+    end
+    self.new(item_object_array)
+  end
+
+end

--- a/spec/item_repository_spec.rb
+++ b/spec/item_repository_spec.rb
@@ -65,4 +65,28 @@ RSpec.describe ItemRepository do
     expect(repo.find_all_by_price_in_range(1..3)).to eq([item1, item2])
   end
 
+  it "finds all items by a given merchant number" do
+    item1 = Item.new({id: 1, name: "test", description: "test_description", unit_price: 1, created_at: "8:07pm UTC", updated_at: "2:34pm UTC", merchant_id: 001})
+    item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 3, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 001})
+    repo = ItemRepository.new([item1, item2])
+
+    expect(repo.find_all_by_merchant_id(001)).to eq([item1, item2])
+
+    item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 3, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 002})
+    repo = ItemRepository.new([item1, item2])
+
+    expect(repo.find_all_by_merchant_id(001)).to eq([item1])
+  end
+
+  xit "creates a new item in the @all library with given attributes and the next sequential ID number" do
+    item1 = Item.new({id: 1, name: "test", description: "test_description", unit_price: 1, created_at: "8:07pm UTC", updated_at: "2:34pm UTC", merchant_id: 001})
+    item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 3, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 001})
+    repo = ItemRepository.new([item1, item2])
+
+    repo.create({id: 1, name: "Test Item 3", description: "test_description", unit_price: 5, created_at: "9:07pm UTC", updated_at: "7:26am UTC", merchant_id: 002})
+    expect(repo.all.length).to eq(3)
+    expect(repo.all[2].class).to eq(Item)
+    expect(repo.all[2].id).to eq(3)
+  end
+
 end

--- a/spec/item_repository_spec.rb
+++ b/spec/item_repository_spec.rb
@@ -1,0 +1,21 @@
+require 'CSV'
+require 'pry'
+require_relative '../lib/item_repository.rb'
+require_relative '../lib/item.rb'
+
+RSpec.describe ItemRepository do
+  it "initializes" do
+    repo = ItemRepository.new [Item.new({id: 1, name: "test", description: "test_description", unit_price: 1, created_at: "8:07pm UTC", updated_at: "2:34pm UTC", merchant_id: 001})]
+    expect(repo).to be_an_instance_of(ItemRepository)
+    expect(repo.all[0]).to be_an_instance_of(Item)
+  end
+
+  it "initializes #from_csv" do
+    repo = ItemRepository.from_csv("./data/items_short.csv")
+    expect(repo).to be_an_instance_of(ItemRepository)
+    expect(repo.all.length).to eq(3)
+    expect(repo.all[0]).to be_an_instance_of(Item)
+  end
+
+
+end

--- a/spec/item_repository_spec.rb
+++ b/spec/item_repository_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe ItemRepository do
     expect(repo.find_all_by_merchant_id(001)).to eq([item1])
   end
 
-  xit "creates a new item in the @all library with given attributes and the next sequential ID number" do
+  it "creates a new item in the @all library with given attributes and the next sequential ID number" do
     item1 = Item.new({id: 1, name: "test", description: "test_description", unit_price: 1, created_at: "8:07pm UTC", updated_at: "2:34pm UTC", merchant_id: 001})
     item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 3, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 001})
     repo = ItemRepository.new([item1, item2])
@@ -89,7 +89,7 @@ RSpec.describe ItemRepository do
     expect(repo.all[2].id).to eq(3)
   end
 
-  xit "can update an item's name, description and unit_price while re-stamping the updated_at with a current timestamp" do
+  it "can update an item's name, description and unit_price while re-stamping the updated_at with a current timestamp" do
     item1 = Item.new({id: 1, name: "test", description: "test_description", unit_price: 1, created_at: "8:07pm UTC", updated_at: "2:34pm UTC", merchant_id: 001})
     item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 3, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 001})
     item3 = Item.new({id: 3, name: "Test Item 3", description: "test_description", unit_price: 5, created_at: "9:07pm UTC", updated_at: "7:26am UTC", merchant_id: 002})
@@ -104,7 +104,7 @@ RSpec.describe ItemRepository do
     expect(repo.all[1].updated_at).not_to eq("12:00pm UTC")
   end
 
-  xit "can delete an item from the library based on given id" do
+  it "can delete an item from the library based on given id" do
     item1 = Item.new({id: 1, name: "test", description: "test_description", unit_price: 1, created_at: "8:07pm UTC", updated_at: "2:34pm UTC", merchant_id: 001})
     item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 3, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 001})
     item3 = Item.new({id: 3, name: "Test Item 3", description: "test_description", unit_price: 5, created_at: "9:07pm UTC", updated_at: "7:26am UTC", merchant_id: 002})

--- a/spec/item_repository_spec.rb
+++ b/spec/item_repository_spec.rb
@@ -61,11 +61,11 @@ RSpec.describe ItemRepository do
     repo = ItemRepository.new([item1, item2])
 
     expect(repo.find_all_by_price_in_range(0..2)).to eq([item1])
-    expect(repo.find_all_by_price_in_range(0..1.5)).to eq([])
+    expect(repo.find_all_by_price_in_range(5..7)).to eq([])
     expect(repo.find_all_by_price_in_range(1..3)).to eq([item1, item2])
   end
 
-  it "finds all items by a given merchant number" do
+  xit "finds all items by a given merchant number" do
     item1 = Item.new({id: 1, name: "test", description: "test_description", unit_price: 1, created_at: "8:07pm UTC", updated_at: "2:34pm UTC", merchant_id: 001})
     item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 3, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 001})
     repo = ItemRepository.new([item1, item2])

--- a/spec/item_repository_spec.rb
+++ b/spec/item_repository_spec.rb
@@ -17,5 +17,37 @@ RSpec.describe ItemRepository do
     expect(repo.all[0]).to be_an_instance_of(Item)
   end
 
+  it 'finds by id' do
+    item1 = Item.new({id: 1, name: "test", description: "test_description", unit_price: 1, created_at: "8:07pm UTC", updated_at: "2:34pm UTC", merchant_id: 001})
+    item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 3, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 001})
+    repo = ItemRepository.new([item1, item2])
+    expect(repo.find_by_id(1)).to be(item1)
+  end
+
+  it 'finds by name' do
+    item1 = Item.new({id: 1, name: "test", description: "test_description", unit_price: 1, created_at: "8:07pm UTC", updated_at: "2:34pm UTC", merchant_id: 001})
+    item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 3, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 001})
+    repo = ItemRepository.new([item1, item2])
+    expect(repo.find_by_name("TeSt")).to be(item1)
+
+  end
+
+  it "finds by description" do
+    item1 = Item.new({id: 1, name: "test", description: "test_description", unit_price: 1, created_at: "8:07pm UTC", updated_at: "2:34pm UTC", merchant_id: 001})
+    item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 3, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 001})
+    repo = ItemRepository.new([item1, item2])
+
+    expect(repo.find_all_with_description("TE")).to eq([item1, item2])
+  end
+
+  it "finds by price" do
+    item1 = Item.new({id: 1, name: "test", description: "test_description", unit_price: 1, created_at: "8:07pm UTC", updated_at: "2:34pm UTC", merchant_id: 001})
+    item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 3, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 001})
+    repo = ItemRepository.new([item1, item2])
+
+    expect(repo.find_all_by_price(1)).to eq([item1])
+    expect(repo.find_all_by_price(2)).to eq([])
+    expect(repo.find_all_by_price(3)).to eq([item2])
+  end
 
 end

--- a/spec/item_repository_spec.rb
+++ b/spec/item_repository_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ItemRepository do
     expect(repo.find_all_with_description("TE")).to eq([item1, item2])
   end
 
-  it "finds by price" do
+  it "finds all items by price" do
     item1 = Item.new({id: 1, name: "test", description: "test_description", unit_price: 1, created_at: "8:07pm UTC", updated_at: "2:34pm UTC", merchant_id: 001})
     item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 3, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 001})
     repo = ItemRepository.new([item1, item2])
@@ -48,6 +48,21 @@ RSpec.describe ItemRepository do
     expect(repo.find_all_by_price(1)).to eq([item1])
     expect(repo.find_all_by_price(2)).to eq([])
     expect(repo.find_all_by_price(3)).to eq([item2])
+
+    item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 1, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 001})
+    repo = ItemRepository.new([item1, item2])
+    expect(repo.find_all_by_price(1)).to eq([item1, item2])
+
+  end
+
+  it "finds all items within a price range" do
+    item1 = Item.new({id: 1, name: "test", description: "test_description", unit_price: 1, created_at: "8:07pm UTC", updated_at: "2:34pm UTC", merchant_id: 001})
+    item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 3, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 001})
+    repo = ItemRepository.new([item1, item2])
+
+    expect(repo.find_all_by_price_in_range(0..2)).to eq([item1])
+    expect(repo.find_all_by_price_in_range(0..1.5)).to eq([])
+    expect(repo.find_all_by_price(1..3)).to eq([item1, item2])
   end
 
 end

--- a/spec/item_repository_spec.rb
+++ b/spec/item_repository_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe ItemRepository do
 
     expect(repo.find_all_by_price_in_range(0..2)).to eq([item1])
     expect(repo.find_all_by_price_in_range(0..1.5)).to eq([])
-    expect(repo.find_all_by_price(1..3)).to eq([item1, item2])
+    expect(repo.find_all_by_price_in_range(1..3)).to eq([item1, item2])
   end
 
 end

--- a/spec/item_repository_spec.rb
+++ b/spec/item_repository_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe ItemRepository do
     expect(repo.find_all_by_price_in_range(1..3)).to eq([item1, item2])
   end
 
-  xit "finds all items by a given merchant number" do
+  it "finds all items by a given merchant number" do
     item1 = Item.new({id: 1, name: "test", description: "test_description", unit_price: 1, created_at: "8:07pm UTC", updated_at: "2:34pm UTC", merchant_id: 001})
     item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 3, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 001})
     repo = ItemRepository.new([item1, item2])
@@ -89,4 +89,28 @@ RSpec.describe ItemRepository do
     expect(repo.all[2].id).to eq(3)
   end
 
+  xit "can update an item's name, description and unit_price while re-stamping the updated_at with a current timestamp" do
+    item1 = Item.new({id: 1, name: "test", description: "test_description", unit_price: 1, created_at: "8:07pm UTC", updated_at: "2:34pm UTC", merchant_id: 001})
+    item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 3, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 001})
+    item3 = Item.new({id: 3, name: "Test Item 3", description: "test_description", unit_price: 5, created_at: "9:07pm UTC", updated_at: "7:26am UTC", merchant_id: 002})
+    repo = ItemRepository.new([item1, item2, item3])
+
+    repo.update(2, {id: 49, name: "Updated Test-Test", description: "This description is updated", unit_price: 9.99, merchant_id: 75})
+
+    expect(repo.all[1].id).to eq(2)
+    expect(repo.all[1].name).to eq("Updated Test-Test")
+    expect(repo.all[1].unit_price).to eq(9.99)
+    expect(repo.all[1].description).to eq("This description is updated")
+    expect(repo.all[1].updated_at).not_to eq("12:00pm UTC")
+  end
+
+  xit "can delete an item from the library based on given id" do
+    item1 = Item.new({id: 1, name: "test", description: "test_description", unit_price: 1, created_at: "8:07pm UTC", updated_at: "2:34pm UTC", merchant_id: 001})
+    item2 = Item.new({id: 2, name: "test-test", description: "another test description", unit_price: 3, created_at: "12:00am utc", udpated_at:"12:00pm UTC", merchant_id: 001})
+    item3 = Item.new({id: 3, name: "Test Item 3", description: "test_description", unit_price: 5, created_at: "9:07pm UTC", updated_at: "7:26am UTC", merchant_id: 002})
+    repo = ItemRepository.new([item1, item2, item3])
+
+    repo.delete(2)
+    expect(repo.all).to eq([item1, item3])
+  end
 end


### PR DESCRIPTION
Now it's ready 😎  I've left the old class method ::from_csv in tact and commented out, so that we have access to it when we're building out the SalesEngine class, but we can remove that from the code before pulling and just leave that record in the item_repository_iteration_0 branch if we want. Otherwise;

- The ItemRepository class initializes with a single argument, an array of Item object instances ostensibly created by the SalesEngine class.
- It contains some of its own methods, and a few mixedin methods from Findable. 
- I created a helper method within the Item class to help update Items within the ItemRepository's library, this may need some attention if it causes a merge conflict, but I don't think it should ... ? 
- Expecting several criticisms from Hound