### PR TITLE
Refactor: Repo initializers and associated rspec tests

### DIFF
--- a/lib/sales_engine.rb
+++ b/lib/sales_engine.rb
@@ -6,7 +6,7 @@ require_relative './merchant'
 class SalesEngine
   attr_reader :table_hash
   def initialize(table_hash)
-    @table_hash = table_hash  
+    @table_hash = table_hash
   end
 
   def self.from_csv(path_hash)
@@ -20,15 +20,22 @@ class SalesEngine
 
   def items
     item_array = @table_hash[:items].map do |row|
-      Item.new(row)
+      Item.new({id: row[:id].to_i, name: row[:name], description: row[:description], unit_price: BigDecimal(row[:unit_price]), merchant_id: row[:merchant_id].to_i, created_at: row[:created_at], updated_at: row[:updated_at]})
     end
     ItemRepository.new(item_array)
   end
 
   def merchants
     merchant_array = @table_hash[:merchants].map do |row|
-      Merchant.new(row)
+      Merchant.new({id: row[:id].to_i, name: row[:name]})
     end
     MerchantRepository.new(merchant_array)
+  end
+
+  def invoices
+    invoice_array = @table_hash[:invoices].map do |row|
+      Invoice.new({id: row[:id].to_i, customer_id: row[:customer_id].to_i, merchant_id: row[:merchant_id].to_i, status: row[:status].to_sym, created_at: row[:created_at], updated_at: row[:updated_at]})
+    end
+    InvoiceRepository.new(invoice_array)
   end
 end

--- a/spec/invoice_repository_spec.rb
+++ b/spec/invoice_repository_spec.rb
@@ -2,6 +2,7 @@ require 'RSpec'
 require 'SimpleCov'
 require_relative '../lib/invoice.rb'
 require_relative '../lib/invoice_repository.rb'
+require_relative '../lib/sales_engine.rb'
 SimpleCov.start
 
 RSpec.describe InvoiceRepository do
@@ -71,5 +72,13 @@ RSpec.describe InvoiceRepository do
     expect(invoice_repo.all).to eq([invoice_3])
     invoice_repo.delete(3)
     expect(invoice_repo.all).to eq([])
+  end
+
+  it 'initializes from SalesEngine#invoices()' do
+    se = SalesEngine.from_csv({:invoices => "./data/invoices.csv"})
+    invoice_repo = se.invoices
+    expect(invoice_repo).to be_a(InvoiceRepository) #Test basic initialization
+    expect(invoice_repo.find_by_id(521)).to be_a(Invoice)
+    expect((invoice_repo.find_by_id(521)).status).to eq(:returned)
   end
 end

--- a/spec/merchant_repository_spec.rb
+++ b/spec/merchant_repository_spec.rb
@@ -99,6 +99,6 @@ RSpec.describe MerchantRepository do
   it 'find a merchant by id from csv' do
     se = SalesEngine.from_csv({ :items => "./data/items.csv", :merchants => "./data/merchants.csv" })
     mr = se.merchants
-    expect(mr.find_by_id("12334105").name).to eq("Shopin1901")
+    expect(mr.find_by_id(12334105).name).to eq("Shopin1901")
   end
 end


### PR DESCRIPTION
This refactor affects the initialization methods, such that instances of Item, Merchant and Invoice will initialize with attributes formatted to appropriate data types, not necessarily as the `string` default we get from the `CSV.read` method. 

- For Merchant:
     - `id` forced to `Integer`
     - `name` left as `String`
- For Item: 
     - `id` and `merchant_id` forced to `Integer` 
     - `unit_price` formatted as `BigDecimal`
     - All other attributes left as `String`

I wasn't sure what we wanted to do with our timestamps, so I've left those formatted as strings, but we can change that as well if we decide we need to!